### PR TITLE
Add shadow to home page card text to make it more legible when obstructed by characters

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -56,12 +56,12 @@
 
 body.dark{
     .card p{
-        text-shadow: 2px 2px 5px var(--text-light);
+        text-shadow: 0px 0px 6px var(--text-light);
     }
 }
 
 body.light{
     .card p{
-        text-shadow: 2px 2px 5px var(--bg-light);
+        text-shadow: 0px 0px 6px var(--bg-light);
     }
 }

--- a/css/home.css
+++ b/css/home.css
@@ -1,8 +1,3 @@
-:root {
-    --text-light: #191919;
-    --bg-light: #fff9f2;
-}
-
 .grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
@@ -54,14 +49,14 @@
     margin: 0;
 }
 
-body.dark{
-    .card p{
+body.dark {
+    .card p {
         text-shadow: 0px 0px 6px var(--text-light);
     }
 }
 
-body.light{
-    .card p{
+body.light {
+    .card p {
         text-shadow: 0px 0px 6px var(--bg-light);
     }
 }

--- a/css/home.css
+++ b/css/home.css
@@ -1,3 +1,8 @@
+:root {
+    --text-light: #191919;
+    --bg-light: #fff9f2;
+}
+
 .grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
@@ -47,5 +52,16 @@
 
 .card p {
     margin: 0;
-    text-shadow: 2px 2px 5px black
+}
+
+body.dark{
+    .card p{
+        text-shadow: 2px 2px 5px var(--text-light);
+    }
+}
+
+body.light{
+    .card p{
+        text-shadow: 2px 2px 5px var(--bg-light);
+    }
 }

--- a/css/home.css
+++ b/css/home.css
@@ -47,4 +47,5 @@
 
 .card p {
     margin: 0;
+    text-shadow: 2px 2px 5px black
 }


### PR DESCRIPTION
Yeah uhhh I guess I'm here again.... Hope you don't mind!

So basically, I noticed that some of the characters in the card elements on the home page (on desktop, this is the case for the Characters list and Relationships cards) obstruct the text a little.

So I just added a little shadow, which is the same color as the background to make it not visible when not hovered over, and *tried* to change the shadow color depending on the applied theme.

I tried my best to make it look half-decent on both themes, but the dark mode shadow does look and work better, just because of how white shadows are.

Below is a little comparison!

Dark mode, no shadow:
![image](https://github.com/user-attachments/assets/93474e7e-917a-459c-aa04-f30033f766af)

Dark mode, with shadow:
![image](https://github.com/user-attachments/assets/a7a846ca-1eb3-498a-b5c3-3a53fe6d5299)

Light mode, no shadow:
![image](https://github.com/user-attachments/assets/ba7f115a-e00e-43e9-a419-d8e0ac8e4b9c)

Light mode, with shadow:
![image](https://github.com/user-attachments/assets/06979672-9d96-4875-ab42-8c2bff10b82c)
